### PR TITLE
Keep Sticky-Header hidden on page load

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -10,6 +10,7 @@
 	z-index: 99998;
 	box-sizing: border-box;
 	-moz-box-sizing: border-box;
+	visibility: hidden;
 }
 .admin-bar #thsp-sticky-header {
 	top: 32px;


### PR DESCRIPTION
Sticky header is visible momentarily after the page initially loads. This change keeps the header hidden until visitors scroll to the user param.